### PR TITLE
Modify push_images.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ override.tf.json
 /workspace/gitserver/.terraform/
 **/key.pem
 **/key.rsa
+
+# Container images
+_image**

--- a/container-images/push_images.sh
+++ b/container-images/push_images.sh
@@ -65,9 +65,11 @@ importImages() {
       if [[ $repository_name == *""* ]]; then
         echo "Repository is empty '/'"
         gw_image_full_name="$glasswallRegistry/$image_name:$tag"
+        gw_image_tgged_name="$image_name:$tag"
       else
         echo "Repository is NOT empty '/'"
         gw_image_full_name="$glasswallRegistry/$repository_name/$image_name:$tag"
+        gw_image_tgged_name="$repository_name/$image_name:$tag"
       fi
 
       client_image_full_name="$final_registry/$image_name:$tag"
@@ -99,7 +101,7 @@ importImages() {
       echo "Image ID is:" $image_exists
     fi
 
-    docker tag "$gw_image_full_name" "$client_image_full_name"
+    docker tag "$gw_image_tgged_name" "$client_image_full_name"
     echo "Image tagged:" $client_image_full_name
 
     docker push $client_image_full_name


### PR DESCRIPTION
push_images.sh was not working, it was importing the container images to my local docker but it wasn't pushing them, because the images on my local were named like `rabbitmqoperator/cluster-operator:1.0.0` as opposed to `gwicapcontainerregistry.azurecr.io/rabbitmqoperator/cluster-operator:1.0.0`