### PR TITLE
remove unused variables and update source module

### DIFF
--- a/environments/installer/04_rancher-clusters/main.tf
+++ b/environments/installer/04_rancher-clusters/main.tf
@@ -18,7 +18,7 @@ data "terraform_remote_state" "rancher_server" {
 }
 
 module "rancher_clusters" {
-    source                            = "../../../workspace/icap-multi-cluster-no-vault"
+    source                            = "../../../workspace/proto-multi-clusters"
     organisation                      = ""
     environment                       = ""
     branch                            = "release"
@@ -31,8 +31,6 @@ module "rancher_clusters" {
     dns_zone                          = "" # needs to be an existing azure dns zone
     subscription_id                   = ""
     tenant_id                         = ""
-    client_id                         = ""
-    client_secret                     = ""
     azure_keyvault_name               = ""
     azure_keyvault_resource_group     = ""
     rancher_suffix                    = data.terraform_remote_state.rancher_server.outputs.rancher_suffix

--- a/modules/rancher-bootstrap/common.tf
+++ b/modules/rancher-bootstrap/common.tf
@@ -55,8 +55,8 @@ resource "azurerm_dns_zone" "main" {
 
 resource "azurerm_dns_ns_record" "child" {
   name                = local.zone_prefix
-  zone_name           = "icap-proxy.curlywurly.me"
-  resource_group_name = "gw-icap-rg-dns"
+  zone_name           = azurerm_dns_zone.main.name
+  resource_group_name = module.resource_group.name
   ttl                 = 300
   records             = azurerm_dns_zone.main.name_servers
 }

--- a/workspace/icap-multi-cluster-no-vault/main.tf
+++ b/workspace/icap-multi-cluster-no-vault/main.tf
@@ -66,7 +66,7 @@ module "setting" {
   setting_value     = var.rancher_api_url
 }
 
-# module.setting reboots the rancher server (it also recycles the certs) which might be 
+# module.setting reboots the rancher server (it also recycles the certs) which might be
 # causing issues with the catalog deployment right below.
 resource "time_sleep" "wait_60_for_rancher_setting" {
   depends_on      = [module.setting]

--- a/workspace/icap-multi-cluster-no-vault/variables.tf
+++ b/workspace/icap-multi-cluster-no-vault/variables.tf
@@ -14,16 +14,6 @@ variable "branch" {
   type        = string
 }
 
-variable "client_id" {
-  description = "Client ID (Confidential, non-commitable)"
-  type        = string
-}
-
-variable "client_secret" {
-  description = "Client Secret (Confidential, non-commitable)"
-  type        = string
-}
-
 variable "subscription_id" {
   description = "Subscription ID"
   type        = string


### PR DESCRIPTION
This will remove the unused `client_id` and `client_secret` variables from the `icap-multi-cluster-no-vault` module.

It also updates the rancher-bootstrap `azurerm_dns_zone` to use parameterized values